### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/script.js
+++ b/script.js
@@ -46,7 +46,7 @@ $(document).ready(function () {
 
     if (e.ctrlKey && e.key === 'c') {
       e.preventDefault(); 
-      $('.prompt').before(`<div class="line">&gt; ${command}</div>`); 
+      $('<div class="line"></div>').text('> ' + command).insertBefore('.prompt'); 
       $('.prompt').remove(); 
       addPrompt(); 
       window.scrollTo(0, document.body.scrollHeight);


### PR DESCRIPTION
Potential fix for [https://github.com/veeryaa/fadelfr/security/code-scanning/3](https://github.com/veeryaa/fadelfr/security/code-scanning/3)

In general, the fix is to ensure user-controlled text is not treated as HTML. Instead of concatenating `command` into an HTML string and passing it to jQuery (which interprets it as HTML), we should create elements or use `.text()` to insert the value as plain text so that special characters are escaped automatically.

For this snippet, the best, behavior-preserving approach is to change the problematic `.before()` call so that `command` is inserted as text content. A simple pattern is:

- Create a new `<div class="line">` element.
- Set its text to the prompt symbol plus the command (`'> ' + command`) using `.text()`.
- Insert that element before `.prompt`.

This keeps the visual output the same (`> some command`) while preventing HTML in `command` from being interpreted. Concretely, in `script.js` around line 49, replace:

```js
$('.prompt').before(`<div class="line">&gt; ${command}</div>`);
```

with:

```js
$('<div class="line"></div>')
  .text('> ' + command)
  .insertBefore('.prompt');
```

This change stays within the shown file, uses only jQuery (already present), and does not alter other logic. Other uses of `command` (such as lines 28 and 40) are also HTML sinks for tainted data, but CodeQL specifically flagged line 49; per your constraints we only adjust that shown snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
