### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/script.js
+++ b/script.js
@@ -25,7 +25,7 @@ $(document).ready(function () {
         return;
       }
 
-      $('.prompt').before(`<div class='line'>&gt; ${command}</div>`);
+      $('<div class="line"></div>').text('> ' + command).insertBefore('.prompt');
       $('.prompt').remove(); 
 
       if (command === 'clear') {


### PR DESCRIPTION
Potential fix for [https://github.com/veeryaa/fadelfr/security/code-scanning/1](https://github.com/veeryaa/fadelfr/security/code-scanning/1)

In general, to fix DOM text being reinterpreted as HTML, avoid passing untrusted strings into APIs that treat the string as HTML (e.g., jQuery’s `.html()`, `.append(string)`, `.before(string)`), and instead insert them as text via `.text()`, `.innerText`, or equivalent. If you must create HTML structure, build the elements programmatically and set the untrusted portions via text properties (e.g., `text()`, `textContent`) so they are automatically escaped.

For this specific code, the best fix without changing functionality is to ensure `command` is inserted as text, not as HTML, while preserving the surrounding `<div class='line'>` structure. Rather than building the entire string with a template literal and letting jQuery parse it as HTML, we can create the `<div>` element with jQuery, set its text to `"> " + command`, and then insert that element before `.prompt`. This preserves the visual behavior (showing `> <user command>` as a line), but ensures any HTML-like content in `command` is escaped and rendered as plain text. Concretely, in `script.js`, replace line 28’s HTML string-based `.before(...)` call with a version that uses ` $('<div class="line"></div>').text('> ' + command)` and inserts that element before `.prompt`. No new imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
