### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/script.js
+++ b/script.js
@@ -37,7 +37,8 @@ $(document).ready(function () {
       if (responses[command]) {
         $('#terminal').append(`<div class='line'>${responses[command]}</div>`);
       } else {
-        $('#terminal').append(`<div class='line' style='color:#ff3333'>command not found: ${command}</div>`);
+        const $errorLine = $('<div class="line" style="color:#ff3333"></div>').text('command not found: ' + command);
+        $('#terminal').append($errorLine);
       }
 
       addPrompt();


### PR DESCRIPTION
Potential fix for [https://github.com/veeryaa/fadelfr/security/code-scanning/2](https://github.com/veeryaa/fadelfr/security/code-scanning/2)

In general, to fix this type of vulnerability, ensure that untrusted data from the DOM (or any user input) is not interpreted as HTML. Instead, insert it into the page using APIs that treat the data as plain text (`textContent`, jQuery `.text()`, or building text nodes), or properly escape it before using it in HTML.

For this specific code, the best minimal fix without changing functionality is to stop interpolating `command` into an HTML string passed to `.append()`, and instead create a new element, set its text content to the message including `command`, and then append that element. This ensures that any HTML meta-characters in `command` are escaped by the browser and rendered as text. Concretely:
- Replace line 40 so that it no longer does string interpolation inside an HTML fragment.
- Create a `<div>` with the same `class='line'` and style, then set its `.text()` to `"command not found: " + command`.
- Append that element to `#terminal`.

This keeps the visual behavior (red error line showing the command) while preventing any HTML in `command` from being executed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
